### PR TITLE
Fixup backport MakeFile.real for crosscompile

### DIFF
--- a/Makefile.real
+++ b/Makefile.real
@@ -87,12 +87,7 @@ install: modules
 	@$(MAKE) -C $(KLIB_BUILD) M=$(BACKPORT_PWD)			\
 		INSTALL_MOD_DIR=$(KMODDIR) $(KMODPATH_ARG)		\
 		modules_install
-	@./scripts/blacklist.sh $(KLIB)/ $(KLIB)/$(KMODDIR)
-	@./scripts/compress_modules.sh $(KLIB)/$(KMODDIR)
-	@./scripts/check_depmod.sh
 	@./scripts/backport_firmware_install.sh
-	@/sbin/depmod -a
-	@./scripts/update-initramfs.sh $(KLIB)
 	@echo
 	@echo Your backported driver modules should be installed now.
 	@echo Reboot.


### PR DESCRIPTION
Used guide from (https://developer.toradex.com/knowledge-base/kernel-backports-integration) 
ISSUE with old modules build before backport is no wiped out in KLIB (module-deployment-direcory
And depmod check.